### PR TITLE
Fix misaligned note layout

### DIFF
--- a/_notes/tensor-norms-quantum-entanglement.md
+++ b/_notes/tensor-norms-quantum-entanglement.md
@@ -13,3 +13,4 @@ A write-up of my notes on entanglement tests using tensor norms and related idea
   <div class="note-box" style="border:1px solid #ccc; padding:1rem; margin-top:1rem;">
       <iframe src="{{ '/assets/html/tensor-norms-quantum-entanglement.html' | relative_url }}" width="100%" height="1800px" style="border:none; margin-top:1rem;" loading="lazy"></iframe>
   </div>
+</div>


### PR DESCRIPTION
## Summary
- fix closing div in tensor norms note

## Testing
- `bundle exec jekyll build`
- `tidy -errors _site/_notes/tensor-norms-quantum-entanglement/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6842b3af79048332a7f4c3e1391132ee