### PR TITLE
Add Math Problem Solver web UI with Drive integration

### DIFF
--- a/assets/css/math-solver.css
+++ b/assets/css/math-solver.css
@@ -1,0 +1,118 @@
+.solver-hero {
+  background: radial-gradient(circle at 20% 20%, #ecf5ff, #f8fbff 45%, #fff 80%);
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  padding: 2.5rem;
+  margin: 2rem 0;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.04);
+}
+
+.solver-hero__content {
+  max-width: 840px;
+}
+
+.eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  color: #2563eb;
+  margin: 0 0 0.5rem;
+  font-weight: 700;
+}
+
+.lede {
+  font-size: 1.1rem;
+  color: #4b5563;
+  line-height: 1.7;
+  margin-top: 0.75rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  background: #2563eb;
+  color: white;
+  border-radius: 999px;
+  border: none;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.pill:hover { transform: translateY(-2px); box-shadow: 0 10px 30px rgba(37,99,235,0.25); }
+.pill:active { transform: translateY(0); box-shadow: none; }
+.pill--ghost { background: transparent; color: #2563eb; border: 1px solid #2563eb; }
+
+.hero-actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; flex-wrap: wrap; }
+
+.solver-app {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 1.75rem;
+  margin: 1.5rem 0;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.05);
+}
+
+.card__header { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; flex-wrap: wrap; }
+.card__header h2 { margin: 0; }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; }
+.field { display: flex; flex-direction: column; gap: 0.4rem; }
+.field--full { grid-column: 1 / -1; }
+
+label { font-weight: 700; color: #111827; }
+textarea, input, select {
+  width: 100%;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 0.75rem 0.85rem;
+  font-size: 1rem;
+  background: #f9fafb;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+textarea:focus, input:focus, select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  background: white;
+}
+
+.hint { color: #6b7280; font-size: 0.9rem; margin: 0; }
+.checkbox-row { display: flex; align-items: center; gap: 0.5rem; font-weight: 600; }
+
+.actions { display: flex; gap: 0.75rem; margin-top: 1rem; flex-wrap: wrap; }
+
+.solution {
+  min-height: 140px;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 12px;
+  padding: 1.25rem;
+  font-family: "Inter", "SF Mono", "Consolas", monospace;
+  white-space: pre-wrap;
+  line-height: 1.65;
+  position: relative;
+}
+
+.solution .badge { position: absolute; top: 12px; right: 12px; font-size: 0.8rem; color: #94a3b8; }
+.solution strong { color: #ffffff; }
+.solution h3, .solution h4 { color: #bfdbfe; margin-top: 1rem; }
+.solution ol, .solution ul { margin-left: 1.25rem; }
+
+.stacked-actions { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; }
+
+.range-labels { display: flex; justify-content: space-between; color: #6b7280; font-size: 0.85rem; margin-top: -0.25rem; }
+
+.card__header .pill { font-size: 0.85rem; padding: 0.35rem 0.75rem; }
+
+@media (max-width: 640px) {
+  .solver-hero { padding: 1.5rem; }
+  .solver-app { padding: 1.25rem; }
+}
+

--- a/assets/js/math-solver.js
+++ b/assets/js/math-solver.js
@@ -1,0 +1,298 @@
+const formState = {
+  provider: 'openai',
+  openaiKey: '',
+  openrouterKey: '',
+  driveClientId: '',
+  driveApiKey: '',
+  saveToDrive: false,
+  problem: '',
+  hints: '',
+  context: '',
+  parameters: '',
+  temperature: 0.15,
+  maxTokens: 1200,
+};
+
+const STORAGE_KEY = 'math-solver-preferences-v1';
+let driveAuthInstance = null;
+let driveReady = false;
+
+function loadState() {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (!saved) return;
+  try {
+    const parsed = JSON.parse(saved);
+    Object.assign(formState, parsed);
+  } catch (err) {
+    console.warn('Could not parse saved state', err);
+  }
+}
+
+function persistState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(formState));
+  const badge = document.getElementById('persistStatus');
+  if (badge) {
+    badge.textContent = 'Settings saved locally';
+    badge.classList.add('pill--ghost');
+  }
+}
+
+function bindInputs() {
+  const bindings = ['provider', 'openaiKey', 'openrouterKey', 'driveClientId', 'driveApiKey', 'problem', 'hints', 'context', 'parameters'];
+  bindings.forEach((field) => {
+    const el = document.getElementById(field);
+    if (!el) return;
+    if (formState[field]) el.value = formState[field];
+    el.addEventListener('input', (event) => {
+      formState[field] = event.target.value;
+      persistState();
+    });
+  });
+
+  const temperature = document.getElementById('temperature');
+  if (temperature) {
+    temperature.value = formState.temperature;
+    temperature.addEventListener('input', (event) => {
+      formState.temperature = Number(event.target.value);
+      persistState();
+    });
+  }
+
+  const maxTokens = document.getElementById('maxTokens');
+  if (maxTokens) {
+    maxTokens.value = formState.maxTokens;
+    maxTokens.addEventListener('input', (event) => {
+      formState.maxTokens = Number(event.target.value);
+      persistState();
+    });
+  }
+
+  const saveToDrive = document.getElementById('saveToDrive');
+  if (saveToDrive) {
+    saveToDrive.checked = formState.saveToDrive;
+    saveToDrive.addEventListener('change', (event) => {
+      formState.saveToDrive = event.target.checked;
+      persistState();
+    });
+  }
+}
+
+function renderStatus(text, kind = 'ghost') {
+  const status = document.getElementById('solveStatus');
+  if (status) {
+    status.textContent = text;
+    status.className = `pill pill--${kind === 'ghost' ? 'ghost' : ''}`.trim();
+  }
+}
+
+function renderSolution(html) {
+  const container = document.getElementById('solution');
+  if (!container) return;
+  container.innerHTML = html;
+  if (window.MathJax && typeof window.MathJax.typesetPromise === 'function') {
+    window.MathJax.typesetPromise([container]);
+  }
+}
+
+function buildPrompt() {
+  const { problem, hints, context, parameters } = formState;
+  const parts = [
+    `Problem: ${problem}`,
+    hints ? `Hints: ${hints}` : '',
+    context ? `Context: ${context}` : '',
+    parameters ? `Additional parameters: ${parameters}` : '',
+  ].filter(Boolean);
+  return parts.join('\n\n');
+}
+
+async function callModel(prompt) {
+  const provider = formState.provider;
+  const temperature = formState.temperature;
+  const maxTokens = formState.maxTokens;
+  const systemPrompt = `You are an expert math tutor that mirrors the reasoning pipeline from the Colab notebook GPT_math_queue_GPT_html. You interpret a problem, restate it, lay out subgoals, solve step-by-step with proofs where relevant, and summarize the final numeric or symbolic result. Prefer LaTeX for math formatting.`;
+  const body = {
+    model: provider === 'openrouter' ? 'openrouter/anthropic/claude-3.5-sonnet' : 'gpt-4o-mini',
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: prompt },
+    ],
+    temperature,
+    max_tokens: maxTokens,
+  };
+
+  const headers = { 'Content-Type': 'application/json' };
+  let endpoint = '';
+  if (provider === 'openrouter') {
+    endpoint = 'https://openrouter.ai/api/v1/chat/completions';
+    headers['Authorization'] = `Bearer ${formState.openrouterKey}`;
+    headers['HTTP-Referer'] = window.location.origin;
+    headers['X-Title'] = 'Math Problem Solver';
+  } else {
+    endpoint = 'https://api.openai.com/v1/chat/completions';
+    headers['Authorization'] = `Bearer ${formState.openaiKey}`;
+  }
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`API error (${response.status}): ${errorText}`);
+  }
+
+  const data = await response.json();
+  const choice = data.choices?.[0]?.message?.content || 'No response generated.';
+  return choice;
+}
+
+function buildTranscript(prompt, answer) {
+  const now = new Date().toISOString();
+  return `Math Problem Solver Transcript\n${now}\n\n${prompt}\n\n---\n\n${answer}`;
+}
+
+async function ensureDrive() {
+  if (!window.gapi) throw new Error('Google API not loaded yet.');
+  if (driveReady) return;
+  const { driveClientId, driveApiKey } = formState;
+  if (!driveClientId || !driveApiKey) throw new Error('Provide Drive client ID and API key.');
+
+  return new Promise((resolve, reject) => {
+    window.gapi.load('client:auth2', async () => {
+      try {
+        await window.gapi.client.init({
+          apiKey: driveApiKey,
+          clientId: driveClientId,
+          discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
+          scope: 'https://www.googleapis.com/auth/drive.file',
+        });
+        driveAuthInstance = window.gapi.auth2.getAuthInstance();
+        driveReady = true;
+        driveAuthInstance.isSignedIn.listen(updateDriveBadge);
+        updateDriveBadge(driveAuthInstance.isSignedIn.get());
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function updateDriveBadge(signedIn) {
+  const badge = document.getElementById('driveStatus');
+  if (!badge) return;
+  badge.textContent = signedIn ? 'Signed in to Drive' : 'Not signed in';
+  badge.style.color = signedIn ? '#16a34a' : '#6b7280';
+}
+
+async function signIntoDrive() {
+  try {
+    await ensureDrive();
+    if (!driveAuthInstance) throw new Error('Drive auth not ready.');
+    if (!driveAuthInstance.isSignedIn.get()) {
+      await driveAuthInstance.signIn();
+    }
+    updateDriveBadge(driveAuthInstance.isSignedIn.get());
+  } catch (err) {
+    alert(`Drive sign-in failed: ${err.message}`);
+  }
+}
+
+async function uploadToDrive(filename, content) {
+  if (!driveAuthInstance || !driveAuthInstance.isSignedIn.get()) return null;
+  const boundary = '-------314159265358979323846';
+  const delimiter = `\r\n--${boundary}\r\n`;
+  const closeDelim = `\r\n--${boundary}--`;
+  const metadata = {
+    name: filename,
+    mimeType: 'text/plain',
+  };
+
+  const multipartRequestBody =
+    delimiter +
+    'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
+    JSON.stringify(metadata) +
+    delimiter +
+    'Content-Type: text/plain\r\n\r\n' +
+    content +
+    closeDelim;
+
+  const request = window.gapi.client.request({
+    path: '/upload/drive/v3/files',
+    method: 'POST',
+    params: { uploadType: 'multipart' },
+    headers: { 'Content-Type': `multipart/related; boundary=${boundary}` },
+    body: multipartRequestBody,
+  });
+
+  const file = await request;
+  return file.result?.id;
+}
+
+function clearForm() {
+  ['problem', 'hints', 'context', 'parameters'].forEach((field) => {
+    const el = document.getElementById(field);
+    if (el) el.value = '';
+    formState[field] = '';
+  });
+  persistState();
+  renderSolution('');
+}
+
+async function handleSolve() {
+  const { provider, openaiKey, openrouterKey } = formState;
+  if (provider === 'openai' && !openaiKey) {
+    alert('Add an OpenAI API key.');
+    return;
+  }
+  if (provider === 'openrouter' && !openrouterKey) {
+    alert('Add an OpenRouter API key.');
+    return;
+  }
+  if (!formState.problem) {
+    alert('Add a problem statement.');
+    return;
+  }
+
+  const prompt = buildPrompt();
+  renderStatus('Calling model...');
+  renderSolution('<span class="badge">Running</span>Reasoning...');
+
+  try {
+    const answer = await callModel(prompt);
+    renderStatus('Complete');
+    renderSolution(`<span class="badge">Model</span>${answer}`);
+    const transcript = buildTranscript(prompt, answer);
+    if (formState.saveToDrive) {
+      await ensureDrive();
+      if (driveAuthInstance?.isSignedIn.get()) {
+        const name = `math-solver-${Date.now()}.txt`;
+        await uploadToDrive(name, transcript);
+        updateDriveBadge(true);
+      }
+    }
+  } catch (err) {
+    console.error(err);
+    renderStatus('Error', 'ghost');
+    renderSolution(`<span class="badge">Error</span>${err.message}`);
+  }
+}
+
+function attachEvents() {
+  const solve = document.getElementById('solve');
+  if (solve) solve.addEventListener('click', handleSolve);
+  const clear = document.getElementById('clearForm');
+  if (clear) clear.addEventListener('click', clearForm);
+  const drive = document.getElementById('driveSignIn');
+  if (drive) drive.addEventListener('click', signIntoDrive);
+}
+
+(function bootstrap() {
+  loadState();
+  bindInputs();
+  attachEvents();
+  renderSolution('Share a problem and press "Run solver" to start.');
+})();
+

--- a/index.md
+++ b/index.md
@@ -12,3 +12,5 @@ Hi, I’m **Rathin**. I’m currently a **Research Student** at **Kyushu Univers
 I am an aspiring mathematical scientist with a keen interest in probability and statistics, machine learning and several related areas. As a side hustle, I like learning Asian languages and discussing the application of tech to reducing the learning curve!
 
 This website collects my research work, notes and other random stuff. Feel free to explore and reach out!
+
+Looking for a quick way to test math ideas with GPT? Try the new [Math Problem Solver](/math-solver/) with stored API keys and Drive export.

--- a/math-solver.md
+++ b/math-solver.md
@@ -1,0 +1,129 @@
+---
+layout: default
+title: Math Problem Solver
+permalink: /math-solver/
+---
+
+<section class="solver-hero">
+  <div class="solver-hero__content">
+    <p class="eyebrow">Interactive prototype</p>
+    <h1>Math Problem Solver</h1>
+    <p class="lede">
+      Run the GPT-powered math queue agent directly in the browser, keep your API keys stored locally for reuse,
+      and optionally sign in to Google Drive to save solution transcripts.
+    </p>
+    <div class="hero-actions">
+      <a class="pill" href="#solver-app">Open the app</a>
+      <a class="pill pill--ghost" href="/assets/python/gpt_math_queue_gpt_html.py">View source Python logic</a>
+    </div>
+  </div>
+</section>
+
+<section id="solver-app" class="solver-app card">
+  <header class="card__header">
+    <div>
+      <p class="eyebrow">Configuration</p>
+      <h2>Connect services</h2>
+      <p class="hint">Keys are stored in your browser's local storage only. Nothing leaves your device unless you run a solve.</p>
+    </div>
+  </header>
+  <div class="grid">
+    <div class="field">
+      <label for="provider">Model provider</label>
+      <select id="provider">
+        <option value="openai">OpenAI</option>
+        <option value="openrouter">OpenRouter</option>
+      </select>
+      <p class="hint">Choose the API endpoint for the math agent.</p>
+    </div>
+    <div class="field">
+      <label for="openaiKey">OpenAI API key</label>
+      <input id="openaiKey" name="openaiKey" autocomplete="off" placeholder="sk-..." />
+      <p class="hint">Used when provider is OpenAI. Stored locally after you type.</p>
+    </div>
+    <div class="field">
+      <label for="openrouterKey">OpenRouter API key</label>
+      <input id="openrouterKey" name="openrouterKey" autocomplete="off" placeholder="or-..." />
+      <p class="hint">Used when provider is OpenRouter. Stored locally after you type.</p>
+    </div>
+    <div class="field">
+      <label for="driveClientId">Google Drive Client ID</label>
+      <input id="driveClientId" name="driveClientId" autocomplete="off" placeholder="your-client-id.apps.googleusercontent.com" />
+      <p class="hint">Required for Drive sign-in. Stored locally.</p>
+    </div>
+    <div class="field">
+      <label for="driveApiKey">Google API key</label>
+      <input id="driveApiKey" name="driveApiKey" autocomplete="off" placeholder="Drive API key" />
+      <p class="hint">Used with the Drive client ID to request file access.</p>
+    </div>
+    <div class="field">
+      <label for="saveToDrive" class="checkbox-row">
+        <input type="checkbox" id="saveToDrive" />
+        <span>Save solver transcripts to Drive when signed in</span>
+      </label>
+      <div class="stacked-actions">
+        <button id="driveSignIn" class="pill">Sign in to Drive</button>
+        <span id="driveStatus" class="hint">Not signed in</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="solver-app card">
+  <header class="card__header">
+    <div>
+      <p class="eyebrow">Problem</p>
+      <h2>Describe the task</h2>
+      <p class="hint">Give the model enough structure—add hints, steps, and constraints.</p>
+    </div>
+    <div class="pill pill--ghost" id="persistStatus">Settings saved locally</div>
+  </header>
+  <div class="grid">
+    <div class="field field--full">
+      <label for="problem">Problem statement</label>
+      <textarea id="problem" rows="3" placeholder="Enter the math question in natural language"></textarea>
+    </div>
+    <div class="field field--full">
+      <label for="hints">Hints or partial steps</label>
+      <textarea id="hints" rows="2" placeholder="Key hints, lemmas, or intermediate steps"></textarea>
+    </div>
+    <div class="field">
+      <label for="context">Context</label>
+      <textarea id="context" rows="2" placeholder="Textbook, lecture, or topic focus"></textarea>
+    </div>
+    <div class="field">
+      <label for="parameters">Other parameters</label>
+      <textarea id="parameters" rows="2" placeholder="Difficulty, format, constraints, or evaluation notes"></textarea>
+    </div>
+    <div class="field">
+      <label for="temperature">Creativity</label>
+      <input id="temperature" type="range" min="0" max="1" step="0.05" value="0.15" />
+      <div class="range-labels"><span>deterministic</span><span>creative</span></div>
+    </div>
+    <div class="field">
+      <label for="maxTokens">Max tokens</label>
+      <input id="maxTokens" type="number" min="128" max="4096" value="1200" />
+    </div>
+  </div>
+  <div class="actions">
+    <button id="solve" class="pill">Run solver</button>
+    <button id="clearForm" class="pill pill--ghost">Clear</button>
+  </div>
+</section>
+
+<section class="solver-app card">
+  <header class="card__header">
+    <div>
+      <p class="eyebrow">Output</p>
+      <h2>Reasoning & solution</h2>
+    </div>
+    <div class="pill pill--ghost" id="solveStatus">Idle</div>
+  </header>
+  <article id="solution" class="solution"></article>
+</section>
+
+<link rel="stylesheet" href="/assets/css/math-solver.css">
+<script src="https://apis.google.com/js/api.js" async defer></script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
+<script src="/assets/js/math-solver.js"></script>
+


### PR DESCRIPTION
## Summary
- add a Math Problem Solver page with configurable model provider, stored API keys, and Drive sign-in
- implement front-end logic to call OpenAI/OpenRouter chat completions, persist settings locally, and optionally upload transcripts to Google Drive
- style the experience with a minimalist UI and link from the home page

## Testing
- bundle exec jekyll build *(fails: jekyll executable not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e380e7fac8332a614270d24b04274)